### PR TITLE
Added support for importing texture alpha channels

### DIFF
--- a/TextureMerge/MainWindow.xaml
+++ b/TextureMerge/MainWindow.xaml
@@ -79,9 +79,10 @@
                 </Border>
                 <Grid x:Name="srcGridCR" Visibility="Hidden" Height="25" Width="auto" VerticalAlignment="Bottom" Margin="0,0,0,40" HorizontalAlignment="Center">
                     <Label Content="source" HorizontalAlignment="Left" Margin="0,0,60,0"/>
-                    <Button x:Name="srcRR" Content="R" Margin="0,0,40,0" HorizontalAlignment="Right" Background="#FFCC0000" Style="{StaticResource colorButtonStyle}" Click="SrcRR"/>
-                    <Button x:Name="srcRG" Content="G" Margin="0,0,20,0" HorizontalAlignment="Right" Background="#FF004400" Style="{StaticResource colorButtonStyle}" Click="SrcRG"/>
-                    <Button x:Name="srcRB" Content="B" Margin="0,0,00,0" HorizontalAlignment="Right" Background="#FF000044" Style="{StaticResource colorButtonStyle}" Click="SrcRB"/>
+                    <Button x:Name="srcRR" Content="R" Margin="0,0,60,0" HorizontalAlignment="Right" Background="#FFCC0000" Style="{StaticResource colorButtonStyle}" Click="SrcRR"/>
+                    <Button x:Name="srcRG" Content="G" Margin="0,0,40,0" HorizontalAlignment="Right" Background="#FF004400" Style="{StaticResource colorButtonStyle}" Click="SrcRG"/>
+                    <Button x:Name="srcRB" Content="B" Margin="0,0,20,0" HorizontalAlignment="Right" Background="#FF000044" Style="{StaticResource colorButtonStyle}" Click="SrcRB"/>
+                    <Button x:Name="srcRA" Content="A" Margin="0,0,00,0" HorizontalAlignment="Right" Background="#FF666666" Style="{StaticResource colorButtonStyle}" Click="SrcRA"/>
                 </Grid>
                 <Grid x:Name="srcGridGsR" Visibility="Hidden" Height="25" Width="auto" VerticalAlignment="Bottom" Margin="0,0,0,40" HorizontalAlignment="Center">
                     <Label Content="Grayscale" HorizontalAlignment="Left"/>
@@ -108,9 +109,10 @@
                 </Border>
                 <Grid x:Name="srcGridCG" Visibility="Hidden" Height="25" Width="auto" VerticalAlignment="Bottom" Margin="0,0,0,40" HorizontalAlignment="Center">
                     <Label Content="source" HorizontalAlignment="Left" Margin="0,0,60,0"/>
-                    <Button x:Name="srcGR"  Content="R" Margin="0,0,40,0" HorizontalAlignment="Right" Background="#FF440000" Style="{StaticResource colorButtonStyle}" Click="SrcGR"/>
-                    <Button x:Name="srcGG" Content="G" Margin="0,0,20,0" HorizontalAlignment="Right" Background="#FF00CC00" Style="{StaticResource colorButtonStyle}" Click="SrcGG"/>
-                    <Button x:Name="srcGB" Content="B" Margin="0,0,00,0" HorizontalAlignment="Right" Background="#FF000044" Style="{StaticResource colorButtonStyle}" Click="SrcGB"/>
+                    <Button x:Name="srcGR"  Content="R" Margin="0,0,60,0" HorizontalAlignment="Right" Background="#FF440000" Style="{StaticResource colorButtonStyle}" Click="SrcGR"/>
+                    <Button x:Name="srcGG" Content="G" Margin="0,0,40,0" HorizontalAlignment="Right" Background="#FF00CC00" Style="{StaticResource colorButtonStyle}" Click="SrcGG"/>
+                    <Button x:Name="srcGB" Content="B" Margin="0,0,20,0" HorizontalAlignment="Right" Background="#FF000044" Style="{StaticResource colorButtonStyle}" Click="SrcGB"/>
+                    <Button x:Name="srcGA" Content="A" Margin="0,0,00,0" HorizontalAlignment="Right" Background="#FF666666" Style="{StaticResource colorButtonStyle}" Click="SrcGA"/>
                 </Grid>
                 <Grid x:Name="srcGridGsG" Visibility="Hidden" Height="25" Width="auto" VerticalAlignment="Bottom" Margin="0,0,0,40" HorizontalAlignment="Center">
                     <Label Content="Grayscale" HorizontalAlignment="Left"/>
@@ -137,9 +139,10 @@
                 </Border>
                 <Grid x:Name="srcGridCB" Visibility="Hidden" Height="25" Width="auto" VerticalAlignment="Bottom" Margin="0,0,0,40" HorizontalAlignment="Center">
                     <Label Content="source" HorizontalAlignment="Left" Margin="0,0,60,0"/>
-                    <Button x:Name="srcBR" Content="R" Margin="0,0,40,0" HorizontalAlignment="Right" Background="#FF440000" Style="{StaticResource colorButtonStyle}" Click="SrcBR"/>
-                    <Button x:Name="srcBG" Content="G" Margin="0,0,20,0" HorizontalAlignment="Right" Background="#FF004400" Style="{StaticResource colorButtonStyle}" Click="SrcBG"/>
-                    <Button x:Name="srcBB" Content="B" Margin="0,0,00,0" HorizontalAlignment="Right" Background="#FF0000CC" Style="{StaticResource colorButtonStyle}" Click="SrcBB"/>
+                    <Button x:Name="srcBR" Content="R" Margin="0,0,60,0" HorizontalAlignment="Right" Background="#FF440000" Style="{StaticResource colorButtonStyle}" Click="SrcBR"/>
+                    <Button x:Name="srcBG" Content="G" Margin="0,0,40,0" HorizontalAlignment="Right" Background="#FF004400" Style="{StaticResource colorButtonStyle}" Click="SrcBG"/>
+                    <Button x:Name="srcBB" Content="B" Margin="0,0,20,0" HorizontalAlignment="Right" Background="#FF0000CC" Style="{StaticResource colorButtonStyle}" Click="SrcBB"/>
+                    <Button x:Name="srcBA" Content="A" Margin="0,0,00,0" HorizontalAlignment="Right" Background="#FF666666" Style="{StaticResource colorButtonStyle}" Click="SrcBA"/>
                 </Grid>
                 <Grid x:Name="srcGridGsB" Visibility="Hidden" Height="25" Width="auto" VerticalAlignment="Bottom" Margin="0,0,0,40" HorizontalAlignment="Center">
                     <Label Content="Grayscale" HorizontalAlignment="Left"/>
@@ -165,9 +168,10 @@
                 </Border>
                 <Grid x:Name="srcGridCA" Visibility="Hidden" Height="25" Width="auto" VerticalAlignment="Bottom" Margin="0,0,0,40" HorizontalAlignment="Center">
                     <Label Content="source" HorizontalAlignment="Left" Margin="0,0,60,0"/>
-                    <Button x:Name="srcAR" Content="R" Margin="0,0,40,0" HorizontalAlignment="Right" Background="#FFCC0000" Style="{StaticResource colorButtonStyle}" Click="SrcAR"/>
-                    <Button x:Name="srcAG" Content="G" Margin="0,0,20,0" HorizontalAlignment="Right" Background="#FF004400" Style="{StaticResource colorButtonStyle}" Click="SrcAG"/>
-                    <Button x:Name="srcAB" Content="B" Margin="0,0,00,0" HorizontalAlignment="Right" Background="#FF000044" Style="{StaticResource colorButtonStyle}" Click="SrcAB"/>
+                    <Button x:Name="srcAR" Content="R" Margin="0,0,60,0" HorizontalAlignment="Right" Background="#FFCC0000" Style="{StaticResource colorButtonStyle}" Click="SrcAR"/>
+                    <Button x:Name="srcAG" Content="G" Margin="0,0,40,0" HorizontalAlignment="Right" Background="#FF004400" Style="{StaticResource colorButtonStyle}" Click="SrcAG"/>
+                    <Button x:Name="srcAB" Content="B" Margin="0,0,20,0" HorizontalAlignment="Right" Background="#FF000044" Style="{StaticResource colorButtonStyle}" Click="SrcAB"/>
+                    <Button x:Name="srcAA" Content="A" Margin="0,0,00,0" HorizontalAlignment="Right" Background="#FF666666" Style="{StaticResource colorButtonStyle}" Click="SrcAA"/>
                 </Grid>
                 <Grid x:Name="srcGridGsA" Visibility="Hidden" Height="25" Width="auto" VerticalAlignment="Bottom" Margin="0,0,0,40" HorizontalAlignment="Center">
                     <Label Content="Grayscale" HorizontalAlignment="Left"/>

--- a/TextureMerge/MainWindow.xaml.cs
+++ b/TextureMerge/MainWindow.xaml.cs
@@ -202,6 +202,13 @@ namespace TextureMerge
             UpdateSourceGrid(Channel.Red);
         }
 
+        private async void SrcRA(object sender, RoutedEventArgs e)
+        {
+            merge.SetChannelSource(Channel.Red, Channel.Alpha);
+            RedCh.SetImageThumbnail(await merge.GetChannelThumbnailAsync(Channel.Red));
+            UpdateSourceGrid(Channel.Red);
+        }
+
         private async void SrcGR(object sender, RoutedEventArgs e)
         {
             merge.SetChannelSource(Channel.Green, Channel.Red);
@@ -219,6 +226,13 @@ namespace TextureMerge
         private async void SrcGB(object sender, RoutedEventArgs e)
         {
             merge.SetChannelSource(Channel.Green, Channel.Blue);
+            GreenCh.SetImageThumbnail(await merge.GetChannelThumbnailAsync(Channel.Green));
+            UpdateSourceGrid(Channel.Green);
+        }
+
+        private async void SrcGA(object sender, RoutedEventArgs e)
+        {
+            merge.SetChannelSource(Channel.Green, Channel.Alpha);
             GreenCh.SetImageThumbnail(await merge.GetChannelThumbnailAsync(Channel.Green));
             UpdateSourceGrid(Channel.Green);
         }
@@ -244,6 +258,13 @@ namespace TextureMerge
             UpdateSourceGrid(Channel.Blue);
         }
 
+        private async void SrcBA(object sender, RoutedEventArgs e)
+        {
+            merge.SetChannelSource(Channel.Blue, Channel.Alpha);
+            BlueCh.SetImageThumbnail(await merge.GetChannelThumbnailAsync(Channel.Blue));
+            UpdateSourceGrid(Channel.Blue);
+        }
+
         private async void SrcAR(object sender, RoutedEventArgs e)
         {
             merge.SetChannelSource(Channel.Alpha, Channel.Red);
@@ -261,6 +282,13 @@ namespace TextureMerge
         private async void SrcAB(object sender, RoutedEventArgs e)
         {
             merge.SetChannelSource(Channel.Alpha, Channel.Blue);
+            AlphaCh.SetImageThumbnail(await merge.GetChannelThumbnailAsync(Channel.Alpha));
+            UpdateSourceGrid(Channel.Alpha);
+        }
+
+        private async void SrcAA(object sender, RoutedEventArgs e)
+        {
+            merge.SetChannelSource(Channel.Alpha, Channel.Alpha);
             AlphaCh.SetImageThumbnail(await merge.GetChannelThumbnailAsync(Channel.Alpha));
             UpdateSourceGrid(Channel.Alpha);
         }
@@ -316,6 +344,7 @@ namespace TextureMerge
                 LoadToChannelAsync(Channel.Red, path);
                 LoadToChannelAsync(Channel.Green, path);
                 LoadToChannelAsync(Channel.Blue, path);
+                LoadToChannelAsync(Channel.Alpha, path);
             }
         }
 

--- a/TextureMerge/Merge/MergeWindowMapper.cs
+++ b/TextureMerge/Merge/MergeWindowMapper.cs
@@ -18,7 +18,7 @@ namespace TextureMerge
                     {
                         sourceChannelButton = new Button[]
                         {
-                            srcRR, srcRG, srcRB,
+                            srcRR, srcRG, srcRB, srcRA
                         },
                         loadButton = LoadR,
                         label = redNoDataLabel,
@@ -32,7 +32,7 @@ namespace TextureMerge
                     {
                         sourceChannelButton = new Button[]
                         {
-                            srcGR, srcGG, srcGB,
+                            srcGR, srcGG, srcGB, srcGA
                         },
                         loadButton = LoadG,
                         label = greenNoDataLabel,
@@ -46,7 +46,7 @@ namespace TextureMerge
                     {
                         sourceChannelButton = new Button[]
                         {
-                            srcBR, srcBG, srcBB,
+                            srcBR, srcBG, srcBB, srcBA
                         },
                         loadButton = LoadB,
                         label = blueNoDataLabel,
@@ -60,7 +60,7 @@ namespace TextureMerge
                     {
                         sourceChannelButton = new Button[]
                         {
-                            srcAR, srcAG, srcAB,
+                            srcAR, srcAG, srcAB, srcAA
                         },
                         loadButton = LoadA,
                         label = alphaNoDataLabel,

--- a/TextureMerge/Merge/MergeWindowMethods.cs
+++ b/TextureMerge/Merge/MergeWindowMethods.cs
@@ -268,7 +268,7 @@ namespace TextureMerge
             SetStatus("Loading...", statusBlueColor);
             try
             {
-                var sourceChannel = channel == Channel.Alpha ? Channel.Red : channel;
+                var sourceChannel = channel;
                 await merge.LoadChannelAsync(path, channel, sourceChannel);
                 image.SetImageThumbnail(await merge.GetChannelThumbnailAsync(channel));
                 label.Visibility = Visibility.Hidden;
@@ -297,8 +297,10 @@ namespace TextureMerge
                     return new SolidColorBrush(Color.FromRgb(0, value, 0));
                 case Channel.Blue:
                     return new SolidColorBrush(Color.FromRgb(0, 0, value));
+                case Channel.Alpha:
+                    return new SolidColorBrush(Color.FromRgb(value, value, value));
                 default:
-                    throw new ArgumentException("Invalid channel. Only R, G, B are allowed");
+                    throw new ArgumentException("Invalid channel.");
             }
         }
 
@@ -334,9 +336,7 @@ namespace TextureMerge
                     colorGrid.Visibility = Visibility.Visible;
 
                     int source = (int)merge.GetSourceChannel(channel);
-                    if (source >= 3)
-                        throw new InvalidOperationException("Source channel is something else than R, G, B. (Alpha cannot be source channel)");
-                    for (int i = 0; i < 3; i++)
+                    for (int i = 0; i < 4; i++)
                     {
                         mapper.slots[ichannel].sourceChannelButton[i].Background = GetColorBrushFor((Channel)i, source == i);
                     }


### PR DESCRIPTION
MainWindow.xaml:
1. Added Alpha channel button

MainWindow.xaml.cs:
1. Added SrcRA, SrcGA, SrcBA, SrcAA functions to handle Alpha button click events
2. Modified LoadWholeImage function to make Load whole image valid for Alpha channel

Merge.cs
1. Removed the code that throws an exception when Alpha channel is detected

2. Modified the pixel copy logic in DoMerge function and ExtractChannel function to support Alpha channel

3. Modified LoadChannel function to support Alpha channel

MergeWindowMapper.cs
1. Added Alpha to sourceChannelButton variables of all channels

MergeWindowMethods.cs
1. Removed restrictions on Alpha